### PR TITLE
Allow users to remove old pins with the same name

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const pinName = core.getInput('pin-name');
 const pinataApiKey = core.getInput('pinata-api-key');
 const pinataSecretApiKey = core.getInput('pinata-secret-api-key');
 const verbose = core.getInput('verbose');
+const removeOld = core.getInput('remove-old');
 
 // Getting workspace directory
 const workspace = process.env.GITHUB_WORKSPACE.toString();
@@ -46,11 +47,51 @@ const options = {
     }
 };
 
+// Function to unpin old hashes
+function unpinHash(hashToUnpin) {
+	pinata.unpin(hashToUnpin).then((result) => {
+        if(verbose) {
+            console.log(result);
+        }
+    }).catch((err) => {
+        console.log(err);
+    });
+}
+
+// Function to search for all old pins with the same name and unpin them if they are not the latest one
+function removeOldPinsSaving(hash) {
+	const metadataFilter = {
+		name: pinName,
+	};
+	const filters = {
+		status: "pinned",
+		pageLimit: 1000,
+		pageOffset: 0,
+		metadata: metadataFilter,
+	};
+	pinata.pinList(filters).then((result) => {
+            if(verbose) {
+                console.log(result);
+            }
+			result.rows.forEach((element) => {
+				if (element.ipfs_pin_hash != hash) {
+					unpinHash(element.ipfs_pin_hash);
+				}
+			});
+		}).catch((err) => {
+            console.log(err);
+        });
+}
+
 // Deploying (pining) to IPFS using Pinata from file system
 pinata.pinFromFS(sourcePath, options).then((result) => {
     if(verbose) {
         console.log(result);
         console.log("HASH: " + result.IpfsHash);
+    }
+
+    if(removeOld) {
+        removeOldPinsSaving(result.IpfsHash);
     }
 
     // Providing hash as output parameter of execution


### PR DESCRIPTION
When users add a new pin, often they want to unpin hashes that were previously pinned with the same name. This change allows them to do that by setting remove-old to true in their action configuration.