### PR TITLE
Fix default values of `remove-old` and `verbose`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,11 @@ inputs:
   remove-old:
     description: 'Remove old pin(-s) with same same'
     required: false
-    default: 'false'
+    default: false
   verbose:
     description: 'Verbose mode'
     required: true
-    default: 'false'
+    default: false
 outputs:
   hash:
     description: 'IPFS hash of the uploaded file or directory'


### PR DESCRIPTION
Since the default values of `remove-old` and `verbose` were set as `"false"` (which is a string), the boolean value of `"false"` is actually `true`.

Changing those defaults to actual boolean `false` values will make the logic behave as described: not removing old files/pins by default, and not outputting verbose logs by default.